### PR TITLE
Japx.Decoder.Options to exclude relationships if it's empty

### DIFF
--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -530,12 +530,8 @@ private extension Japx.Encoder {
         }
         object[Consts.APIKeys.attributes] = attributes
         
-        if relationships.isEmpty {
-            if options.includeEmptyRelationships {
+        if relationships.isNotEmpty || options.includeEmptyRelationships {
                 object[Consts.APIKeys.relationships] = relationships
-            }
-        } else {
-            object[Consts.APIKeys.relationships] = relationships
         }
         
         return object

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -107,10 +107,10 @@ public extension Japx.Encoder {
         /// - Tag: includeMetaToCommonNamespce
         public var includeMetaToCommonNamespce: Bool = false
         
-        /// When set to `true` empty object will be encoded send `"relationships": {}`
-        /// When set to `false`field `relationships` will be removed if empty
+        /// When set to `true` an empty relationships object will be send  as empty JSON object `"relationships": {}`.
+        /// When set to `false` an empty object will be removed from the encoded data
         ///
-        /// Defaults to false.
+        /// Defaults to ture. Empty JSON object will be sent.
         ///
         /// - Tag: includeEmptyRelationships
         public var includeEmptyRelationships: Bool = true

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -107,7 +107,7 @@ public extension Japx.Encoder {
         /// - Tag: includeMetaToCommonNamespce
         public var includeMetaToCommonNamespce: Bool = false
         
-        /// When set to `true` an empty relationships object will be send  as empty JSON object `"relationships": {}`.
+        /// When set to `true` an empty relationships object will be send as empty JSON object `"relationships": {}`.
         /// When set to `false` an empty object will be removed from the encoded data
         ///
         /// Defaults to ture. Empty JSON object will be sent.

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -110,7 +110,7 @@ public extension Japx.Encoder {
         /// When set to `true` an empty relationships object will be send as empty JSON object `"relationships": {}`.
         /// When set to `false` an empty object will be removed from the encoded data
         ///
-        /// Defaults to ture. Empty JSON object will be sent.
+        /// Defaults to `true`. Empty JSON object will be sent.
         ///
         /// - Tag: includeEmptyRelationships
         public var includeEmptyRelationships: Bool = true

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -531,7 +531,7 @@ private extension Japx.Encoder {
         object[Consts.APIKeys.attributes] = attributes
         
         if !relationships.isEmpty || options.includeEmptyRelationships {
-                object[Consts.APIKeys.relationships] = relationships
+            object[Consts.APIKeys.relationships] = relationships
         }
         
         return object

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -530,7 +530,7 @@ private extension Japx.Encoder {
         }
         object[Consts.APIKeys.attributes] = attributes
         
-        if relationships.isNotEmpty || options.includeEmptyRelationships {
+        if !relationships.isEmpty || options.includeEmptyRelationships {
                 object[Consts.APIKeys.relationships] = relationships
         }
         

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -120,8 +120,9 @@ public extension Japx.Encoder {
         /// - parameter includeMetaToCommonNamespce: Read more [here](includeMetaToCommonNamespce)
         ///
         /// - returns: The new `Japx.Decoder.Options` instance.
-        public init(includeMetaToCommonNamespce: Bool = false) {
+        public init(includeMetaToCommonNamespce: Bool = false, includeEmptyRelationships: Bool = true) {
             self.includeMetaToCommonNamespce = includeMetaToCommonNamespce
+            self.includeEmptyRelationships = includeEmptyRelationships
         }
     }
 }

--- a/Japx/Classes/Core/Japx.swift
+++ b/Japx/Classes/Core/Japx.swift
@@ -107,6 +107,14 @@ public extension Japx.Encoder {
         /// - Tag: includeMetaToCommonNamespce
         public var includeMetaToCommonNamespce: Bool = false
         
+        /// When set to `true` empty object will be encoded send `"relationships": {}`
+        /// When set to `false`field `relationships` will be removed if empty
+        ///
+        /// Defaults to false.
+        ///
+        /// - Tag: includeEmptyRelationships
+        public var includeEmptyRelationships: Bool = true
+        
         /// Creates an instance with the specified properties.
         ///
         /// - parameter includeMetaToCommonNamespce: Read more [here](includeMetaToCommonNamespce)
@@ -520,7 +528,15 @@ private extension Japx.Encoder {
             object.removeValue(forKey: key)
         }
         object[Consts.APIKeys.attributes] = attributes
-        object[Consts.APIKeys.relationships] = relationships
+        
+        if relationships.isEmpty {
+            if options.includeEmptyRelationships {
+                object[Consts.APIKeys.relationships] = relationships
+            }
+        } else {
+            object[Consts.APIKeys.relationships] = relationships
+        }
+        
         return object
     }
     


### PR DESCRIPTION
According to the JSON:API docs:

> A “relationship object” MUST contain at least one of the following:
> - links: a links object containing at least one of the following:self: a link for the relationship itself (a “relationship link”). 
> - data: resource linkage
> - meta: a meta object that contains non-standard meta-information about the relationship.

Current implementation breaks this requirement.
An empty JSON object will be sent when no relationships are provided.

```
"relationships": {}
```

This leads to API incompatibility with servers with strict validation rules on incoming request data.

The solution we introduce is the encoding option to exclude "relationships" object if it's empty.

Since other apps may rely on current library behavior, we leave the default option to send the empty object, so it will not require any changes on update.