### PR TITLE
Adding Stable Version For Moya

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.0.0")),
        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.2.0")),
-       .package(url: "https://github.com/Moya/Moya.git", .branch("development"))
+       .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "15.0.0"))
     ],
     targets: [
         .target(name: "Japx", path: "Japx/Classes/Core"),


### PR DESCRIPTION
This fixes issue #51 by providing the latest stable version of Moya to depend on