### PR TITLE
Fix Parameters type ambiguity when Alamofire is included

### DIFF
--- a/Japx/Classes/Alamofire/JapxAlamofire.swift
+++ b/Japx/Classes/Alamofire/JapxAlamofire.swift
@@ -45,7 +45,7 @@ extension DataRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default,
-        completionHandler: @escaping (AFDataResponse<Parameters>) -> Void
+        completionHandler: @escaping (AFDataResponse<Alamofire.Parameters>) -> Void
     ) -> Self {
         return response(
             queue: queue,
@@ -70,7 +70,7 @@ extension DownloadRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default,
-        completionHandler: @escaping (AFDownloadResponse<Parameters>) -> Void
+        completionHandler: @escaping (AFDownloadResponse<Alamofire.Parameters>) -> Void
     ) -> Self {
         return response(
             queue: queue,
@@ -98,7 +98,7 @@ public final class JSONAPIResponseSerializer: ResponseSerializer {
         self.options = options
     }
     
-    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Parameters {
+    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Alamofire.Parameters {
         guard error == nil else { throw error! }
         
         guard var data = data, !data.isEmpty else {

--- a/Japx/Classes/Alamofire/JapxAlamofire.swift
+++ b/Japx/Classes/Alamofire/JapxAlamofire.swift
@@ -45,7 +45,7 @@ extension DataRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default,
-        completionHandler: @escaping (AFDataResponse<Alamofire.Parameters>) -> Void
+        completionHandler: @escaping (AFDataResponse<Japx.Parameters>) -> Void
     ) -> Self {
         return response(
             queue: queue,
@@ -70,7 +70,7 @@ extension DownloadRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default,
-        completionHandler: @escaping (AFDownloadResponse<Alamofire.Parameters>) -> Void
+        completionHandler: @escaping (AFDownloadResponse<Japx.Parameters>) -> Void
     ) -> Self {
         return response(
             queue: queue,
@@ -98,7 +98,7 @@ public final class JSONAPIResponseSerializer: ResponseSerializer {
         self.options = options
     }
     
-    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Alamofire.Parameters {
+    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Japx.Parameters {
         guard error == nil else { throw error! }
         
         guard var data = data, !data.isEmpty else {

--- a/Japx/Classes/RxAlamofire/JapxRxAlamofire.swift
+++ b/Japx/Classes/RxAlamofire/JapxRxAlamofire.swift
@@ -35,8 +35,8 @@ extension Reactive where Base: DataRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default
-    ) -> Single<Alamofire.Parameters> {
-        return Single<Alamofire.Parameters>.create { [weak base] (single) -> Disposable in
+    ) -> Single<Japx.Parameters> {
+        return Single<Japx.Parameters>.create { [weak base] (single) -> Disposable in
             let request = base?.responseJSONAPI(
                 queue: queue,
                 includeList: includeList,
@@ -65,8 +65,8 @@ extension Reactive where Base: DownloadRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default
-    ) -> Single<Alamofire.Parameters> {
-        return Single<Alamofire.Parameters>.create { [weak base] (single) -> Disposable in
+    ) -> Single<Japx.Parameters> {
+        return Single<Japx.Parameters>.create { [weak base] (single) -> Disposable in
             let request = base?.responseJSONAPI(
                 queue: queue,
                 includeList: includeList,

--- a/Japx/Classes/RxAlamofire/JapxRxAlamofire.swift
+++ b/Japx/Classes/RxAlamofire/JapxRxAlamofire.swift
@@ -35,8 +35,8 @@ extension Reactive where Base: DataRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default
-    ) -> Single<Parameters> {
-        return Single<Parameters>.create { [weak base] (single) -> Disposable in
+    ) -> Single<Alamofire.Parameters> {
+        return Single<Alamofire.Parameters>.create { [weak base] (single) -> Disposable in
             let request = base?.responseJSONAPI(
                 queue: queue,
                 includeList: includeList,
@@ -65,8 +65,8 @@ extension Reactive where Base: DownloadRequest {
         queue: DispatchQueue = .main,
         includeList: String? = nil,
         options: JapxKit.Decoder.Options = .default
-    ) -> Single<Parameters> {
-        return Single<Parameters>.create { [weak base] (single) -> Disposable in
+    ) -> Single<Alamofire.Parameters> {
+        return Single<Alamofire.Parameters>.create { [weak base] (single) -> Disposable in
             let request = base?.responseJSONAPI(
                 queue: queue,
                 includeList: includeList,


### PR DESCRIPTION
This PR resolves a compilation error: 'Parameters' is ambiguous for type lookup. The conflict occurs because both Alamofire and Japx define a Parameters typealias.

By explicitly namespacing the completion handler to Alamofire.Parameters in JapxAlamofire.swift and JapxRxAlamofire.swift, the compiler can correctly resolve the type when both libraries are present in the same scope.